### PR TITLE
Add jsconfig for path aliases

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `jsconfig.json` to enable `@` alias resolution

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68657137a9c0832cb563b4126fdcf794