### PR TITLE
Add slug and thumbnail url in course creation

### DIFF
--- a/src/app/(admin)/courses/new/page.jsx
+++ b/src/app/(admin)/courses/new/page.jsx
@@ -35,6 +35,13 @@ export default function NewCoursePage() {
             console.error("Upload failed:", error);
         }
     };
+    const generateSlug = (str) => {
+        return str
+            .toLowerCase()
+            .trim()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/(^-|-$)+/g, "");
+    };
     const handleSubmit = async (e) => {
         e.preventDefault();
         const { data: { user }, } = await supabase.auth.getUser();
@@ -46,10 +53,11 @@ export default function NewCoursePage() {
             .insert([
             {
                 title,
+                slug: generateSlug(title),
                 description,
                 price: parseFloat(price),
                 teacher_id: user.id,
-                thumbnail,
+                thumbnail_url: thumbnail,
             },
         ])
             .select();


### PR DESCRIPTION
## Summary
- generate a slug for new courses
- save uploaded thumbnail as `thumbnail_url`
- keep the edit page consistent with the `thumbnail_url` field

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68657eeaa114832cbbcb5fe4b9be204a