### PR TITLE
Add enrollments table and fetch students

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -21,6 +21,14 @@ CREATE TABLE courses (
   view_count INT DEFAULT 0
 );
 
+-- Enrollments Table
+CREATE TABLE enrollments (
+  student_id UUID REFERENCES profiles(id),
+  course_id UUID REFERENCES courses(id),
+  enrolled_at TIMESTAMPTZ DEFAULT now(),
+  PRIMARY KEY (student_id, course_id)
+);
+
 -- Content Items
 CREATE TYPE content_type AS ENUM ('video', 'quiz', 'text', 'assignment');
 CREATE TABLE content_items (

--- a/src/app/(admin)/courses/[slug]/students/page.jsx
+++ b/src/app/(admin)/courses/[slug]/students/page.jsx
@@ -14,9 +14,16 @@ export default function CourseStudentsPage({ params, }) {
                 .eq("slug", slug)
                 .single();
             if (courseData) {
-                // This is a placeholder. We need a table that links students to courses.
-                // For now, we'll just display a message.
-                setStudents([]);
+                const { data, error } = await supabase
+                    .from("enrollments")
+                    .select("profiles(id, full_name)")
+                    .eq("course_id", courseData.id);
+                if (error) {
+                    console.error("Error fetching students:", error);
+                }
+                else if (data) {
+                    setStudents(data.map((enroll) => enroll.profiles));
+                }
             }
         };
         fetchStudents();

--- a/src/app/(admin)/students/page.jsx
+++ b/src/app/(admin)/students/page.jsx
@@ -7,9 +7,16 @@ export default function StudentsPage() {
     const supabase = createClient();
     useEffect(() => {
         const fetchStudents = async () => {
-            // This is a placeholder. We need to fetch all students.
-            // For now, we'll just display a message.
-            setStudents([]);
+            const { data, error } = await supabase
+                .from("profiles")
+                .select("id, full_name, enrollments(courses(title, slug))")
+                .eq("role", "student");
+            if (error) {
+                console.error("Error fetching students:", error);
+            }
+            else if (data) {
+                setStudents(data);
+            }
         };
         fetchStudents();
     }, [supabase]);
@@ -21,7 +28,12 @@ export default function StudentsPage() {
         </CardHeader>
         <CardContent>
           {students.length > 0 ? (<ul>
-              {students.map((student) => (<li key={student.id}>{student.full_name}</li>))}
+              {students.map((student) => (<li key={student.id} className="mb-2">
+                  <div>{student.full_name}</div>
+                  {student.enrollments && student.enrollments.length > 0 && (<ul className="ml-4 list-disc">
+                        {student.enrollments.map((enroll) => (<li key={enroll.course_id}>{enroll.courses.title}</li>))}
+                      </ul>)}
+                </li>))}
             </ul>) : (<p>Nehum Estudante encontrado.</p>)}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- extend schema with `enrollments` table
- pull enrolled course information when listing all students
- query course-specific enrollments on the students page

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68657eebdcc0832c84846cf4fecdd7b8