### PR TITLE
Add teacher role guard for admin routes

### DIFF
--- a/src/app/(admin)/layout.jsx
+++ b/src/app/(admin)/layout.jsx
@@ -1,12 +1,18 @@
 import { Sidebar } from '@/components/admin/Sidebar';
 import { AuthProvider } from '@/providers/AuthProvider';
-export default function AdminLayout({ children, }) {
-    return (<AuthProvider>
-      <div className="flex h-screen bg-slate-50">
-        <Sidebar />
-        <main className="flex-1 overflow-y-auto p-8 bg-gradient-to-br from-slate-50 to-blue-50">
-          {children}
-        </main>
-      </div>
-    </AuthProvider>);
+import TeacherGuard from '@/components/TeacherGuard';
+
+export default function AdminLayout({ children }) {
+  return (
+    <AuthProvider>
+      <TeacherGuard>
+        <div className="flex h-screen bg-slate-50">
+          <Sidebar />
+          <main className="flex-1 overflow-y-auto p-8 bg-gradient-to-br from-slate-50 to-blue-50">
+            {children}
+          </main>
+        </div>
+      </TeacherGuard>
+    </AuthProvider>
+  );
 }

--- a/src/components/TeacherGuard.jsx
+++ b/src/components/TeacherGuard.jsx
@@ -1,0 +1,39 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/providers/AuthProvider';
+import { createClient } from '@/lib/supabase/client';
+
+export default function TeacherGuard({ children }) {
+  const { session, loading } = useAuth();
+  const [authorized, setAuthorized] = useState(false);
+  const router = useRouter();
+  const supabase = createClient();
+
+  useEffect(() => {
+    const checkRole = async () => {
+      if (loading) return;
+      if (!session) {
+        router.replace('/auth/login');
+        return;
+      }
+      const { data } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', session.user.id)
+        .single();
+      if (data?.role !== 'teacher') {
+        router.replace('/');
+        return;
+      }
+      setAuthorized(true);
+    };
+    checkRole();
+  }, [loading, session, supabase, router]);
+
+  if (loading || !authorized) {
+    return <div>Loading...</div>;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- create `TeacherGuard` component to validate user role
- wrap admin layout with `TeacherGuard`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68657eed3a80832c86628d0c5faf0d87